### PR TITLE
Add hosting/ docs for ssdisabilityassoc.com DNS + M365 email

### DIFF
--- a/hosting/AGENTS.md
+++ b/hosting/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md — hosting/
+
+This file provides guidance to AI coding agents (Claude Code, and any tool that reads
+`AGENTS.md`) when working in this directory.
+
+> Note: This `hosting/` tree is **unrelated to the prj-vm testimonials app** at the repo
+> root (kevcoder.com). It holds deployment/DNS notes for a separate property,
+> **ssdisabilityassoc.com**. Nearest-file-wins, so this `AGENTS.md` governs `hosting/`.
+
+## What this is
+
+DNS, email, and hosting configuration notes for **ssdisabilityassoc.com**. There is no code
+or build here — these are operational runbooks for changing live DNS without breaking the
+existing site. The authoritative step-by-step lives in
+[`ms365/dns_and_email.md`](ms365/dns_and_email.md); read it before touching any record.
+
+## The setup (split web/email DNS — the part that's easy to break)
+
+Two providers serve one domain, so web records and email records must be kept apart:
+
+- **Web** is **Google Sites**, anchored by `CNAME www → ghs.googlehosted.com`. This record is
+  load-bearing — replacing it (e.g. with a Microsoft `A @ → <IP>`) takes the live site down.
+- **Email** is **Microsoft 365**. Only email-class records get added: `MX @`, the SPF `TXT @`,
+  `CNAME autodiscover`, plus optional `_dmarc` TXT and the two DKIM CNAMEs M365 issues.
+- **`dev.ssdisabilityassoc.com`** is an isolated dev subdomain via `CNAME dev → <app host>`;
+  safe to change without affecting web or email.
+
+Two domains are in play, and they are configured differently:
+
+- `ssdisabilityassoc.com` — the primary; holds the real web + email records above.
+- `ssdisabilityassociates.com` — an alias that **301-redirects** (`@` and `www`) to the
+  primary. Use provider domain-forwarding, **not** a CNAME, so it stays a true redirect.
+
+## Hard rules when editing DNS
+
+- Never modify or remove `CNAME www → ghs.googlehosted.com`.
+- Never add an `A @` pointing at Microsoft — email setup needs no apex A record.
+- Keep a **single** SPF `TXT` record; if one already exists, merge includes into it rather
+  than adding a second (e.g. `v=spf1 include:spf.protection.outlook.com include:_spf.google.com -all`).
+- Email lives on `ssdisabilityassoc.com`, so that domain (not just
+  `ssdisabilityassociates.com`) must be added and verified in M365.
+
+The DNS provider is not yet recorded here; confirm it before giving UI-specific steps.

--- a/hosting/CLAUDE.md
+++ b/hosting/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/hosting/ms365/dns_and_email.md
+++ b/hosting/ms365/dns_and_email.md
@@ -1,0 +1,302 @@
+Got it—this is enough context to give you a **precise, conflict-safe deployment plan** that won’t break your Google Site while you add Microsoft 365 email and a dev environment.
+
+***
+
+# ✅ ✅ Current State (Confirmed)
+
+* ✅ `ssdisabilityassoc.com` → **Google Sites (live site)**
+* ✅ You are adding **`ssdisabilityassociates.com` in Microsoft 365**
+* ✅ You want **email on `ssdisabilityassoc.com`**
+* ✅ You want a **dev subdomain**
+
+***
+
+# ⚠️ CRITICAL PRINCIPLE (READ THIS FIRST)
+
+You are mixing **Google Sites (web)** + **Microsoft 365 (email)**
+
+👉 This **is supported**, BUT ONLY IF:
+
+* You **DO NOT change web records**
+* You **ONLY add email-related DNS records**
+
+***
+
+# ✅ ✅ MASTER PLAN (SAFE ORDER)
+
+Follow in this exact order:
+
+***
+
+# ✅ STEP 1 — DO NOT TOUCH Google Sites DNS
+
+Your working site depends on:
+
+```
+CNAME
+www → ghs.googlehosted.com
+```
+
+✅ This MUST remain exactly as-is  
+❌ Do NOT replace it with Microsoft records
+
+***
+
+# ✅ STEP 2 — Configure Microsoft 365 (Email Only)
+
+You already added:
+
+```
+ssdisabilityassociates.com
+```
+
+But your email is:
+
+```
+admin@ssdisabilityassoc.com
+```
+
+👉 Therefore you MUST:
+
+### ✅ ALSO ADD:
+
+```
+ssdisabilityassoc.com
+```
+
+in Microsoft 365
+
+***
+
+## 2.1 Verify Domain
+
+Add this TXT (from M365):
+
+```
+Type: TXT
+Host: @
+Value: MS=msXXXXXXXX
+```
+
+✅ Wait until verified
+
+***
+
+## 2.2 Add Email DNS (SAFE)
+
+Add ONLY these records:
+
+### 📩 MX (mail routing)
+
+```
+Type: MX
+Host: @
+Value: ssdisabilityassoc-com.mail.protection.outlook.com
+Priority: 0
+```
+
+***
+
+### ✅ SPF
+
+```
+Type: TXT
+Host: @
+Value: v=spf1 include:spf.protection.outlook.com -all
+```
+
+***
+
+### ✅ Autodiscover
+
+```
+Type: CNAME
+Host: autodiscover
+Value: autodiscover.outlook.com
+```
+
+***
+
+### ✅ (Optional but recommended)
+
+#### DMARC
+
+```
+TXT
+_dmarc → v=DMARC1; p=none
+```
+
+***
+
+#### DKIM
+
+Enable in Microsoft 365 → add 2 CNAMEs it gives you
+
+***
+
+## ⚠️ IMPORTANT: Check for existing SPF
+
+If you already have a TXT SPF record, you must **merge**, not duplicate:
+
+Example:
+
+```
+v=spf1 include:spf.protection.outlook.com include:_spf.google.com -all
+```
+
+***
+
+# ✅ STEP 3 — Configure Alias Domain
+
+## Goal:
+
+```
+ssdisabilityassociates.com → ssdisabilityassoc.com
+```
+
+***
+
+## ✅ Solution: Domain Redirect (NOT DNS pointing)
+
+In your DNS provider:
+
+### Forward rules:
+
+```
+@      → https://ssdisabilityassoc.com
+www    → https://ssdisabilityassoc.com
+Type: 301
+```
+
+✅ This ensures:
+
+* SEO consistency
+* Users always land on your main domain
+
+***
+
+# ✅ STEP 4 — Configure `dev.ssdisabilityassoc.com`
+
+This is isolated and safe.
+
+***
+
+## 4.1 Add DNS Record
+
+If your redesigned site is on modern hosting (likely):
+
+```
+Type: CNAME
+Host: dev
+Value: your-app-hostname
+```
+
+Example:
+
+```
+dev → yourapp.azurewebsites.net
+```
+
+***
+
+## 4.2 On Your Hosting Platform
+
+Add custom domain:
+
+```
+dev.ssdisabilityassoc.com
+```
+
+Enable:
+
+```
+SSL / HTTPS
+```
+
+***
+
+# ✅ STEP 5 — Final DNS Snapshot (CORRECT DESIGN)
+
+## ✅ `ssdisabilityassoc.com`
+
+```
+CNAME   www            → ghs.googlehosted.com   ✅ KEEP (Google Sites)
+
+MX      @              → ssdisabilityassoc-com.mail.protection.outlook.com
+
+TXT     @              → v=spf1 include:spf.protection.outlook.com -all
+
+CNAME   autodiscover   → autodiscover.outlook.com
+
+CNAME   dev            → your-new-host
+
+TXT     _dmarc         → v=DMARC1; p=none
+```
+
+***
+
+## ✅ `ssdisabilityassociates.com`
+
+```
+Forward:
+@      → https://ssdisabilityassoc.com
+www    → https://ssdisabilityassoc.com
+```
+
+***
+
+# ✅ STEP 6 — Validation Checklist
+
+## 🌐 Website
+
+* ✅ `ssdisabilityassoc.com` loads Google Site
+* ✅ `www.ssdisabilityassoc.com` works
+* ✅ `ssdisabilityassociates.com` redirects
+
+***
+
+## 📧 Email
+
+* ✅ Send → <admin@ssdisabilityassoc.com>
+* ✅ Receive → from Gmail
+* ✅ Reply works
+
+***
+
+## 🧪 Dev Site
+
+* ✅ <https://dev.ssdisabilityassoc.com> loads
+* ✅ SSL valid
+
+***
+
+# ⚠️ COMMON BREAK SCENARIOS (Avoid These)
+
+❌ Replacing:
+
+```
+www → ghs.googlehosted.com
+```
+
+❌ Adding:
+
+```
+A @ → Microsoft IP
+```
+
+❌ Multiple SPF records
+
+❌ Using CNAME instead of redirect for alias domain
+
+***
+
+# 🚀 If You Want Me to Finish This With You
+
+I can:
+
+* ✅ Inspect your actual DNS live
+* ✅ Tell you exactly what to delete/keep
+* ✅ Walk your GoDaddy / Cloudflare UI step-by-step
+* ✅ Verify M365 domain page settings
+
+Just tell me your **DNS provider** 👍


### PR DESCRIPTION
Adds a `hosting/` documentation area (unrelated to the prj-vm testimonials app) for the **ssdisabilityassoc.com** property.

## Contents
- **`hosting/ms365/dns_and_email.md`** — runbook for the split **Google Sites (web) / Microsoft 365 (email)** DNS setup: domain verification, MX/SPF/autodiscover/DKIM/DMARC records, the `ssdisabilityassociates.com` 301 alias redirect, and the `dev.` subdomain. (Moved here from the repo root.)
- **`hosting/AGENTS.md`** — source-of-truth guidance: the split-DNS architecture and the hard rules for editing live DNS without breaking the site.
- **`hosting/CLAUDE.md`** — `@AGENTS.md` import shim so Claude Code reads the same content.

## Notes
- The DNS provider isn't recorded yet; the docs flag this as an open item before provider-specific UI steps can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)